### PR TITLE
Fix Stage/Progress selection

### DIFF
--- a/src/ItemEdit.js
+++ b/src/ItemEdit.js
@@ -139,9 +139,17 @@ const ItemEdit = ({ index, roadmap, onChange, onDone }) => {
 
   const handleSuggestionSelect = (index, event) => {
     const values = [...dateFields];
-    if (event.target.name && event.target.name.includes('Stage')) {
+    if (
+      event.target.innerText &&
+      roadmap.labels.map((label) => label.name).includes(event.target.innerText)
+    ) {
       values[index].stage = event.suggestion;
-    } else if (event.target.name && event.target.name.includes('Progress')) {
+    } else if (
+      event.target.innerText &&
+      ['Not Started', 'In Progress', 'Complete'].includes(
+        event.target.innerText,
+      )
+    ) {
       values[index].progress = event.suggestion;
     }
     setDateFields(values);

--- a/src/ItemEdit.js
+++ b/src/ItemEdit.js
@@ -137,19 +137,11 @@ const ItemEdit = ({ index, roadmap, onChange, onDone }) => {
     setDateFields(values);
   };
 
-  const handleSuggestionSelect = (index, event) => {
+  const handleSuggestionSelect = (index, name, event) => {
     const values = [...dateFields];
-    if (
-      event.target.innerText &&
-      roadmap.labels.map((label) => label.name).includes(event.target.innerText)
-    ) {
+    if (name && name.includes('Stage')) {
       values[index].stage = event.suggestion;
-    } else if (
-      event.target.innerText &&
-      ['Not Started', 'In Progress', 'Complete'].includes(
-        event.target.innerText,
-      )
-    ) {
+    } else if (name && name.includes('Progress')) {
       values[index].progress = event.suggestion;
     }
     setDateFields(values);
@@ -271,7 +263,11 @@ const ItemEdit = ({ index, roadmap, onChange, onDone }) => {
                         handleAdditionalInputChange(index, event)
                       }
                       onSuggestionSelect={(event) =>
-                        handleSuggestionSelect(index, event)
+                        handleSuggestionSelect(
+                          index,
+                          `${index}DateStage`,
+                          event,
+                        )
                       }
                       name={`${index}DateStage`}
                       htmlFor={`${index}DateStage`}
@@ -292,7 +288,11 @@ const ItemEdit = ({ index, roadmap, onChange, onDone }) => {
                         handleAdditionalInputChange(index, event)
                       }
                       onSuggestionSelect={(event) =>
-                        handleSuggestionSelect(index, event)
+                        handleSuggestionSelect(
+                          index,
+                          `${index}DateProgress`,
+                          event,
+                        )
                       }
                       icon={<FormDown />}
                       reverse


### PR DESCRIPTION
`event.target.name` did not exist on the event coming from the selection. For the time being, we will pass the `name` of the FormField into the function directly. via suggestion here https://github.com/grommet/grommet-roadmap/pull/14#issuecomment-822468193

Closes #13 